### PR TITLE
Fix address translation when switching to/from Bare mode

### DIFF
--- a/src/main/java/li/cil/sedna/riscv/R5CPUTemplate.java
+++ b/src/main/java/li/cil/sedna/riscv/R5CPUTemplate.java
@@ -778,6 +778,21 @@ final class R5CPUTemplate implements R5CPU {
                         }
                     }
 
+                    // From RISC-V Privileged Architectures, section 4.2.1
+                    // "Changing satp.MODE from Bare to other modes and vice versa also takes effect immediately,
+                    // without the need to execute an SFENCE.VMA instruction."
+                    if (xlen == R5.XLEN_32) {
+                        if ((satp & R5.SATP_MODE_MASK32) == R5.SATP_MODE_NONE ||
+                            (validatedValue & R5.SATP_MODE_MASK32) == R5.SATP_MODE_NONE) {
+                            flushTLB();
+                        }
+                    } else {
+                        if ((satp & R5.SATP_MODE_MASK64) == R5.SATP_MODE_NONE ||
+                            (validatedValue & R5.SATP_MODE_MASK64) == R5.SATP_MODE_NONE) {
+                            flushTLB();
+                        }
+                    }
+
                     satp = validatedValue;
 
                     return true; // Invalidate fetch cache.

--- a/src/main/java/li/cil/sedna/riscv/R5CPUTemplate.java
+++ b/src/main/java/li/cil/sedna/riscv/R5CPUTemplate.java
@@ -782,13 +782,13 @@ final class R5CPUTemplate implements R5CPU {
                     // "Changing satp.MODE from Bare to other modes and vice versa also takes effect immediately,
                     // without the need to execute an SFENCE.VMA instruction."
                     if (xlen == R5.XLEN_32) {
-                        if ((satp & R5.SATP_MODE_MASK32) == R5.SATP_MODE_NONE ||
-                            (validatedValue & R5.SATP_MODE_MASK32) == R5.SATP_MODE_NONE) {
+                        if (((satp & R5.SATP_MODE_MASK32) == R5.SATP_MODE_NONE) !=
+                            ((validatedValue & R5.SATP_MODE_MASK32) == R5.SATP_MODE_NONE)) {
                             flushTLB();
                         }
                     } else {
-                        if ((satp & R5.SATP_MODE_MASK64) == R5.SATP_MODE_NONE ||
-                            (validatedValue & R5.SATP_MODE_MASK64) == R5.SATP_MODE_NONE) {
+                        if (((satp & R5.SATP_MODE_MASK64) == R5.SATP_MODE_NONE) !=
+                            ((validatedValue & R5.SATP_MODE_MASK64) == R5.SATP_MODE_NONE)) {
                             flushTLB();
                         }
                     }


### PR DESCRIPTION
TLB entries from Bare mode (VA == PA) should not be visible after switching to another mode (and vice versa).
From RISC-V Privileged Architectures, section 4.2.1:
> Changing satp.MODE from Bare to other modes and vice versa also takes effect immediately, without the need to execute an SFENCE.VMA instruction.

Also discussed here. https://github.com/riscv/riscv-isa-manual/issues/538

In theory, we shouldn't be doing any kind of address translation / TLB lookup at all in Bare mode since VA == PA. In that case, there wouldn't be any TLB entries to leak. But since the `MemoryMappedDevice` and the offset into it is whats actually cached in our TLB, it actually makes sense for sedna to cache even in Bare mode.
So instead, the best solution is to flush the TLB whenever switching to/from Bare mode.

The kernel actually relies on this, which is why we can't boot newer kernels. So, this fixes #6