### PR TITLE
fix page-misaligned accesses

### DIFF
--- a/src/main/java/li/cil/sedna/riscv/R5CPUTemplate.java
+++ b/src/main/java/li/cil/sedna/riscv/R5CPUTemplate.java
@@ -1165,7 +1165,10 @@ final class R5CPUTemplate implements R5CPU {
         storex(address, value, Sizes.SIZE_64, Sizes.SIZE_64_LOG2);
     }
 
-    private long loadx(final long address, final int size, final int sizeLog2) throws R5MemoryAccessException {
+    protected long loadx(final long address, final int size, final int sizeLog2) throws R5MemoryAccessException {
+        if((address & ~R5.PAGE_ADDRESS_MASK) != ((address + size/8 - 1) & ~R5.PAGE_ADDRESS_MASK)) {
+            return loadxPageMisaligned(address, size, sizeLog2);
+        }
         final int index = (int) ((address >>> R5.PAGE_ADDRESS_SHIFT) & (TLB_SIZE - 1));
         final int alignment = size / 8; // Enforce aligned memory access.
         final int alignmentMask = alignment - 1;
@@ -1183,6 +1186,10 @@ final class R5CPUTemplate implements R5CPU {
     }
 
     private void storex(final long address, final long value, final int size, final int sizeLog2) throws R5MemoryAccessException {
+        if((address & ~R5.PAGE_ADDRESS_MASK) != ((address + size/8 - 1) & ~R5.PAGE_ADDRESS_MASK)) {
+            storexPageMisaligned(address, value, size, sizeLog2);
+            return;
+        }
         final int index = (int) ((address >>> R5.PAGE_ADDRESS_SHIFT) & (TLB_SIZE - 1));
         final int alignment = size / 8; // Enforce aligned memory access.
         final int alignmentMask = alignment - 1;
@@ -1197,6 +1204,21 @@ final class R5CPUTemplate implements R5CPU {
         } else {
             storeSlow(address, value, sizeLog2);
         }
+    }
+
+    private void storexPageMisaligned(final long address, final long value, final int size, final int sizeLog2) throws R5MemoryAccessException {
+        for (int i = 0; i < size/8; i++) {
+            long valueByte = value >> i*8 & 0xff;
+            storex(address + i, valueByte, 8, 0);
+        }
+    }
+
+    private long loadxPageMisaligned(final long address, final int size, final int sizeLog2) throws R5MemoryAccessException {
+        long value = 0;
+        for (int i = 0; i < size/8; i++) {
+            value |= (loadx(address + i, 8, 0) & 0xff) << (i*8);
+        }
+        return value;
     }
 
     private TLBEntry fetchPageSlow(final long address) throws R5MemoryAccessException {


### PR DESCRIPTION
I believe I hunted down the cause of #12: namely, paging wasn't implemented correctly for memory accesses that spanned more than one page. An access (load/store) on page boundary should take both ptes into account, but what happened was only the first one was considered and consecutive page in physical, instead of virtual memory was accessed.

Before I was consistently getting segfaults trying to compile the simplest things with tcc (even "tcc empty.c -E" wasn't working) with the fix, I didn't get any crash yet...

The fix I created is rather naive, doing access byte by byte, but I think an application shouldn't expect performance to be great - the specification says: "The base ISA supports misaligned accesses, but these might run extremely slowly depending on the implementation".

One thing I'm not sure about is alignment handling in tlb. Why is it there? With my fix, multi-page accesses are handled before everything else, as series of aligned accesses, and I don't see including alignment in tlb hash doing anything. Was the idea to only have one hash check per access in loadx/storex, and check if misaligned access involves more than one page in load-/storeSlow? I suppose checking for page boundary on every access isn't free, maybe doing it like that would make the normal case faster?

Maybe this will be useful to someone: Because I was getting nowhere with debugging of generated code, I made a non-generated version of sedna cpu (https://github.com/ja2142/sedna/tree/non-generated-R5CPU). It's crude, and slow, but I don't think I'd be able to get anywhere without it. I also wrote a riscv test for accesses on a page boundary (https://github.com/ja2142/riscv-tests/tree/page_misaligned_access_test).