### PR TITLE
Fix setting of satp to MODE=Bare

### DIFF
--- a/src/main/java/li/cil/sedna/riscv/R5CPUTemplate.java
+++ b/src/main/java/li/cil/sedna/riscv/R5CPUTemplate.java
@@ -797,7 +797,7 @@ final class R5CPUTemplate implements R5CPU {
                     if (xlen != R5.XLEN_32) {
                         // We only support Sv39 and Sv48. On unsupported writes spec says just don't change anything.
                         final long mode = validatedValue & R5.SATP_MODE_MASK64;
-                        if (mode != R5.SATP_MODE_SV39 && mode != R5.SATP_MODE_SV48) {
+                        if (mode != R5.SATP_MODE_NONE && mode != R5.SATP_MODE_SV39 && mode != R5.SATP_MODE_SV48) {
                             break;
                         }
                     }


### PR DESCRIPTION
Since sedna only supports Sv39 and Sv48 paging modes, `writeCSR` checks writes to `satp` to make sure one of those modes has been selected, else the write is ignored. However, we need to also allow returning to bare mode (i.e. no address translation). This patch adds SATP_MODE_NONE to the allowed modes.
When the kernel added support for sv48 in 5.17, it added autodetection of which paging modes the CPU supports. This works by temporarily changing to sv48 mode, checking satp to see if it changed, and then setting satp back to 0 (bare). This last step breaks before this patch and crashes the kernel. After this patch, I can boot a 6.6 kernel successfully.
https://github.com/torvalds/linux/blob/f443e374ae131c168a065ea1748feac6b2e76613/arch/riscv/mm/init.c#L585

Fixes #18 
