### PR TITLE
Implement Atomics Behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ and `Zifencei`. For the uninitiated, this means:
 
 This comes with a couple of caveats:
 
-- The `FENCE` and `FENCE.I` instructions are no-ops and atomic operations do not lock underlying memory. Multi-core
-  setups will behave incorrectly.
+- The `FENCE` and `FENCE.I` instructions are no-ops.
 - Floating-point operations have been reimplemented in software for flag correctness. Meaning they're slow.
 
 ## Instructions and decoding

--- a/src/main/java/li/cil/sedna/api/device/MemoryMappedDevice.java
+++ b/src/main/java/li/cil/sedna/api/device/MemoryMappedDevice.java
@@ -75,4 +75,17 @@ public interface MemoryMappedDevice extends Device {
      * @see Sizes
      */
     void store(final int offset, final long value, final int sizeLog2) throws MemoryAccessException;
+
+    /**
+     * Performs an atomic Compare and Swap operation on this device.
+     *
+     * @param offset   the offset local to the device to write to.
+     * @param value    the value to write to the device.
+     * @param expected the value to compare against
+     * @param sizeLog2 the size of the value to write, log2. See {@link Sizes}.
+     * @return success of the compare and swap
+     * @throws MemoryAccessException if there was an error accessing the data in this device.
+     * @see Sizes
+     */
+    boolean storeCAS(final int offset, final long value, final long expected, final int sizeLog2) throws MemoryAccessException;
 }

--- a/src/main/java/li/cil/sedna/device/flash/FlashMemoryDevice.java
+++ b/src/main/java/li/cil/sedna/device/flash/FlashMemoryDevice.java
@@ -2,13 +2,20 @@ package li.cil.sedna.device.flash;
 
 import li.cil.sedna.api.Sizes;
 import li.cil.sedna.api.device.MemoryMappedDevice;
+import li.cil.sedna.api.memory.MemoryAccessException;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 public final class FlashMemoryDevice implements MemoryMappedDevice {
     private final ByteBuffer data;
     private final boolean readonly;
+
+    private static final VarHandle view16 = MethodHandles.byteBufferViewVarHandle(short[].class, ByteOrder.LITTLE_ENDIAN);
+    private static final VarHandle view32 = MethodHandles.byteBufferViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+    private static final VarHandle view64 = MethodHandles.byteBufferViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
     public FlashMemoryDevice(final ByteBuffer data, final boolean readonly) {
         this.data = data;
@@ -66,5 +73,19 @@ public final class FlashMemoryDevice implements MemoryMappedDevice {
             case Sizes.SIZE_64_LOG2 -> data.putLong(offset, value);
             default -> throw new IllegalArgumentException();
         }
+    }
+
+    @Override
+    public boolean storeCAS(final int offset, final long value, final long expected, final int sizeLog2) throws MemoryAccessException {
+        if (readonly || (offset < 0 || offset > data.limit() - (1 << sizeLog2)))
+            throw new MemoryAccessException();
+
+        return switch (sizeLog2) {
+            case Sizes.SIZE_8_LOG2 -> throw new MemoryAccessException();
+            case Sizes.SIZE_16_LOG2 -> view16.compareAndSet(data, offset, expected, value);
+            case Sizes.SIZE_32_LOG2 -> view32.compareAndSet(data, offset, expected, value);
+            case Sizes.SIZE_64_LOG2 -> view64.compareAndSet(data, offset, expected, value);
+            default -> throw new IllegalArgumentException();
+        };
     }
 }

--- a/src/main/java/li/cil/sedna/device/memory/UnsafeMemory.java
+++ b/src/main/java/li/cil/sedna/device/memory/UnsafeMemory.java
@@ -7,8 +7,6 @@ import li.cil.sedna.utils.DirectByteBufferUtils;
 import li.cil.sedna.utils.UnsafeGetter;
 import sun.misc.Unsafe;
 
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
 import java.lang.reflect.Field;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -17,10 +15,6 @@ import java.nio.ByteOrder;
 // Tends to be around 10% faster than ByteBufferMemory during regular emulation.
 public final class UnsafeMemory extends PhysicalMemory {
     private static final Unsafe UNSAFE = UnsafeGetter.get();
-
-    private static final VarHandle view16 = MethodHandles.byteBufferViewVarHandle(short[].class, ByteOrder.LITTLE_ENDIAN);
-    private static final VarHandle view32 = MethodHandles.byteBufferViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
-    private static final VarHandle view64 = MethodHandles.byteBufferViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
     public static PhysicalMemory create(final int size) {
         if ((size & 0b11) != 0)
@@ -120,9 +114,9 @@ public final class UnsafeMemory extends PhysicalMemory {
 
         return switch (sizeLog2) {
             case Sizes.SIZE_8_LOG2 -> throw new MemoryAccessException();
-            case Sizes.SIZE_16_LOG2 -> view16.compareAndSet(buffer, offset, expected, value);
-            case Sizes.SIZE_32_LOG2 -> view32.compareAndSet(buffer, offset, expected, value);
-            case Sizes.SIZE_64_LOG2 -> view64.compareAndSet(buffer, offset, expected, value);
+            case Sizes.SIZE_16_LOG2 -> throw new MemoryAccessException(); //view16.compareAndSet(buffer, offset, expected, value);
+            case Sizes.SIZE_32_LOG2 -> UNSAFE.compareAndSwapInt(null, address + offset, (int)expected, (int)value); //view32.compareAndSet(buffer, offset, expected, value);
+            case Sizes.SIZE_64_LOG2 -> UNSAFE.compareAndSwapLong(null, address + offset, expected, value);
             default -> throw new IllegalArgumentException();
         };
     }

--- a/src/main/java/li/cil/sedna/device/memory/UnsafeMemory.java
+++ b/src/main/java/li/cil/sedna/device/memory/UnsafeMemory.java
@@ -7,6 +7,8 @@ import li.cil.sedna.utils.DirectByteBufferUtils;
 import li.cil.sedna.utils.UnsafeGetter;
 import sun.misc.Unsafe;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.lang.reflect.Field;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -15,6 +17,10 @@ import java.nio.ByteOrder;
 // Tends to be around 10% faster than ByteBufferMemory during regular emulation.
 public final class UnsafeMemory extends PhysicalMemory {
     private static final Unsafe UNSAFE = UnsafeGetter.get();
+
+    private static final VarHandle view16 = MethodHandles.byteBufferViewVarHandle(short[].class, ByteOrder.LITTLE_ENDIAN);
+    private static final VarHandle view32 = MethodHandles.byteBufferViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+    private static final VarHandle view64 = MethodHandles.byteBufferViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
     public static PhysicalMemory create(final int size) {
         if ((size & 0b11) != 0)
@@ -105,5 +111,19 @@ public final class UnsafeMemory extends PhysicalMemory {
         while (src.hasRemaining()) {
             UNSAFE.putByte(address + offset++, src.get());
         }
+    }
+
+    @Override
+    public boolean storeCAS(final int offset, final long value, final long expected, final int sizeLog2) throws MemoryAccessException {
+        if (offset < 0 || offset > getLength() - (1 << sizeLog2))
+            throw new MemoryAccessException();
+
+        return switch (sizeLog2) {
+            case Sizes.SIZE_8_LOG2 -> throw new MemoryAccessException();
+            case Sizes.SIZE_16_LOG2 -> view16.compareAndSet(buffer, offset, expected, value);
+            case Sizes.SIZE_32_LOG2 -> view32.compareAndSet(buffer, offset, expected, value);
+            case Sizes.SIZE_64_LOG2 -> view64.compareAndSet(buffer, offset, expected, value);
+            default -> throw new IllegalArgumentException();
+        };
     }
 }

--- a/src/main/java/li/cil/sedna/device/rtc/GoldfishRTC.java
+++ b/src/main/java/li/cil/sedna/device/rtc/GoldfishRTC.java
@@ -6,6 +6,7 @@ import li.cil.sedna.api.Sizes;
 import li.cil.sedna.api.device.InterruptSource;
 import li.cil.sedna.api.device.MemoryMappedDevice;
 import li.cil.sedna.api.device.rtc.RealTimeCounter;
+import li.cil.sedna.api.memory.MemoryAccessException;
 
 import static java.util.Collections.singleton;
 
@@ -68,5 +69,10 @@ public final class GoldfishRTC implements InterruptSource, MemoryMappedDevice {
     @Override
     public void store(final int offset, final long value, final int sizeLog2) {
         // all no-ops
+    }
+
+    @Override
+    public boolean storeCAS(int offset, long value, long expected, int sizeLog2) throws MemoryAccessException {
+        throw new MemoryAccessException();
     }
 }

--- a/src/main/java/li/cil/sedna/device/serial/UART16550A.java
+++ b/src/main/java/li/cil/sedna/device/serial/UART16550A.java
@@ -9,6 +9,7 @@ import li.cil.sedna.api.device.MemoryMappedDevice;
 import li.cil.sedna.api.device.Resettable;
 import li.cil.sedna.api.device.Steppable;
 import li.cil.sedna.api.device.serial.SerialDevice;
+import li.cil.sedna.api.memory.MemoryAccessException;
 
 import static java.util.Collections.singleton;
 
@@ -428,6 +429,11 @@ public final class UART16550A implements Resettable, Steppable, MemoryMappedDevi
             case UART_MCR_OFFSET -> mcr = (byte) (value & 0b11111);
             case UART_SCR_OFFSET -> scr = (byte) value;
         }
+    }
+
+    @Override
+    public boolean storeCAS(int offset, long value, long expected, int sizeLog2) throws MemoryAccessException {
+        throw new MemoryAccessException();
     }
 
     @Override

--- a/src/main/java/li/cil/sedna/device/syscon/AbstractSystemController.java
+++ b/src/main/java/li/cil/sedna/device/syscon/AbstractSystemController.java
@@ -1,6 +1,7 @@
 package li.cil.sedna.device.syscon;
 
 import li.cil.sedna.api.device.MemoryMappedDevice;
+import li.cil.sedna.api.memory.MemoryAccessException;
 
 public abstract class AbstractSystemController implements MemoryMappedDevice {
     public static final int SYSCON_RESET = 0x1000;
@@ -24,6 +25,15 @@ public abstract class AbstractSystemController implements MemoryMappedDevice {
                 case SYSCON_POWEROFF -> handlePowerOff();
             }
         }
+    }
+
+    @Override
+    public boolean storeCAS(int offset, long value, long expected, int sizeLog2) throws MemoryAccessException {
+        if (expected == 0) {
+            store(offset, value, sizeLog2);
+            return true;
+        } else
+            return false;
     }
 
     protected abstract void handleReset();

--- a/src/main/java/li/cil/sedna/device/virtio/AbstractVirtIODevice.java
+++ b/src/main/java/li/cil/sedna/device/virtio/AbstractVirtIODevice.java
@@ -744,6 +744,11 @@ public abstract class AbstractVirtIODevice implements MemoryMappedDevice, Interr
         }
     }
 
+    @Override
+    public boolean storeCAS(int offset, long value, long expected, int sizeLog2) throws MemoryAccessException {
+        throw new MemoryAccessException();
+    }
+
     ///////////////////////////////////////////////////////////////////
     // InterruptSource
 

--- a/src/main/java/li/cil/sedna/riscv/R5Board.java
+++ b/src/main/java/li/cil/sedna/riscv/R5Board.java
@@ -60,6 +60,7 @@ public final class R5Board implements Board {
     public R5Board() {
         memoryMap = new SimpleMemoryMap();
         rtc = cpu = R5CPU.create(memoryMap);
+        ((SimpleMemoryMap)memoryMap).setCpu(cpu);
 
         flash = new FlashMemoryDevice(FLASH_SIZE);
         clint = new R5CoreLocalInterrupter(rtc);

--- a/src/main/java/li/cil/sedna/riscv/R5CPU.java
+++ b/src/main/java/li/cil/sedna/riscv/R5CPU.java
@@ -28,5 +28,7 @@ public interface R5CPU extends Steppable, Resettable, RealTimeCounter, Interrupt
 
     void setFrequency(int value);
 
+    void notify(long address, int size);
+
     CPUDebugInterface getDebugInterface();
 }

--- a/src/main/java/li/cil/sedna/riscv/R5CPUTemplate.java
+++ b/src/main/java/li/cil/sedna/riscv/R5CPUTemplate.java
@@ -1205,6 +1205,9 @@ final class R5CPUTemplate implements R5CPU {
     }
 
     private void storex(final long address, final long value, final int size, final int sizeLog2) throws R5MemoryAccessException {
+        // Would just use a hook in MemoryMap, but it is inconsistently called.
+        notify(address, size);
+
         final long lastAddress = address + size / 8 - 1;
         if ((address & ~R5.PAGE_ADDRESS_MASK) != (lastAddress & ~R5.PAGE_ADDRESS_MASK)) {
             storexPageMisaligned(address, value, size);
@@ -1215,9 +1218,6 @@ final class R5CPUTemplate implements R5CPU {
         final long hash = address & ~R5.PAGE_ADDRESS_MASK;
         final TLBEntry entry = storeTLB[index];
         if (entry.hash == hash) {
-            // Would just use a hook in MemoryMap, but it is inconsistently called.
-            notify(address, size);
-
             try {
                 entry.device.store((int) (address + entry.toOffset), value, sizeLog2);
             } catch (final MemoryAccessException e) {

--- a/src/main/java/li/cil/sedna/riscv/R5CPUTemplate.java
+++ b/src/main/java/li/cil/sedna/riscv/R5CPUTemplate.java
@@ -2317,7 +2317,6 @@ final class R5CPUTemplate implements R5CPU {
 
     ///////////////////////////////////////////////////////////////////
     // RV32A Standard Extension
-    // TODO: Add RL/AC
 
     @Instruction("LR.W")
     private void lr_w(@Field("rd") final int rd,

--- a/src/main/java/li/cil/sedna/riscv/device/R5CoreLocalInterrupter.java
+++ b/src/main/java/li/cil/sedna/riscv/device/R5CoreLocalInterrupter.java
@@ -11,6 +11,7 @@ import li.cil.sedna.api.device.InterruptSource;
 import li.cil.sedna.api.device.MemoryMappedDevice;
 import li.cil.sedna.api.device.Steppable;
 import li.cil.sedna.api.device.rtc.RealTimeCounter;
+import li.cil.sedna.api.memory.MemoryAccessException;
 import li.cil.sedna.riscv.R5;
 
 import java.util.stream.Collectors;
@@ -145,6 +146,11 @@ public final class R5CoreLocalInterrupter implements Steppable, InterruptSource,
                 }
             }
         }
+    }
+
+    @Override
+    public boolean storeCAS(int offset, long value, long expected, int sizeLog2) throws MemoryAccessException {
+        throw new MemoryAccessException();
     }
 
     private void checkTimeComparators() {

--- a/src/main/java/li/cil/sedna/riscv/device/R5PlatformLevelInterruptController.java
+++ b/src/main/java/li/cil/sedna/riscv/device/R5PlatformLevelInterruptController.java
@@ -6,6 +6,7 @@ import li.cil.sedna.api.Sizes;
 import li.cil.sedna.api.device.InterruptController;
 import li.cil.sedna.api.device.InterruptSource;
 import li.cil.sedna.api.device.MemoryMappedDevice;
+import li.cil.sedna.api.memory.MemoryAccessException;
 import li.cil.sedna.riscv.R5;
 
 import java.util.Arrays;
@@ -190,6 +191,11 @@ public class R5PlatformLevelInterruptController implements MemoryMappedDevice, I
                 }
             }
         }
+    }
+
+    @Override
+    public boolean storeCAS(int offset, long value, long expected, int sizeLog2) throws MemoryAccessException {
+        throw new MemoryAccessException();
     }
 
     @Override

--- a/src/test/java/li/cil/sedna/riscv/ISATests.java
+++ b/src/test/java/li/cil/sedna/riscv/ISATests.java
@@ -53,9 +53,11 @@ public final class ISATests {
 
                         final long toHostAddress = getToHostAddress(elf);
 
-                        final MemoryMap memoryMap = new SimpleMemoryMap();
+                        final SimpleMemoryMap memoryMap = new SimpleMemoryMap();
                         final R5CPU cpu = R5CPU.create(memoryMap);
                         final HostTargetInterface htif = new HostTargetInterface();
+
+                        memoryMap.setCpu(cpu);
 
                         // RAM block below and potentially up to HTIF.
                         if (PHYSICAL_MEMORY_START < toHostAddress) {

--- a/src/test/java/li/cil/sedna/riscv/ISATests.java
+++ b/src/test/java/li/cil/sedna/riscv/ISATests.java
@@ -196,6 +196,11 @@ public final class ISATests {
             }
         }
 
+        @Override
+        public boolean storeCAS(int offset, long value, long expected, int sizeLog2) throws MemoryAccessException {
+            throw new MemoryAccessException(); // Seems trivial to implement, but unnecessary.
+        }
+
         protected void handleCommand() {
             if (toHost != 0) {
                 final int exitcode = (int) (toHost >>> 1);


### PR DESCRIPTION
Implemented full atomics behavior (minus RL/AC) for potential future multicore support.

Zalrsc was implemented by emulating bus snooping with a notify function. When multicore is implemented, the notify mechanism will have to be improved.

Zaamo was implemented using Java features including VarHandle and Unsafe. Unsafe only has support for word and double word. Some devices were omitted (throws MemoryAccessException) due to being out of scope. VirtIO is currently omitted because I am unfamiliar and am not sure if implementing it makes sense.

Direct test for ByteBufferMemory atomic support added with aggressive data racing to verify functionality. No new tests specific to the Zaamo instructions added. I have made tests for Zalrsc that verify they work, but I have not committed them. Existing Zalrsc tests fail, but when recompiled from source they succeed.

Zawrs and Zacas were never defined within the emulator so I haven't implemented them.

FENCE, FENCE.I and RL/AC flags for A instructions are not implemented (NOPs) because, realistically, the emulator's overhead will prevent the spatial/temporal locality that necessitates such features.

Tasks:

- [x] Implement Zalrsc
- [x] Implement Zaamo
- [ ] Add test for Zalrsc
- [x] Add test for Zaamo
- [x] Add support for main memory atomic operations
- [ ] Add device support for atomic operations (if desired)
- [ ] Implement Zawrs (if desired)
- [ ] Implement Zacas (if desired)
- [ ] Review code style, comments, etc.